### PR TITLE
Add new objects to Automake system

### DIFF
--- a/Caramel/Makefile.am
+++ b/Caramel/Makefile.am
@@ -8,6 +8,8 @@ libCaramel_la_LIBADD =
 libCaramel_la_SOURCES = AudioFFT.cpp \
 AudioFFT.h \
 c.convolve_tilde.cpp \
+c.count_tilde.cpp \
+c.fft_tilde.cpp \
 c.freeverb_tilde.cpp \
 c.matrix_tilde.cpp \
 FFTConvolver.cpp \

--- a/Chocolate/Makefile.am
+++ b/Chocolate/Makefile.am
@@ -9,6 +9,7 @@ libChocolate_la_SOURCES = c.bang.cpp \
 c.blackboard.cpp \
 c.breakpoints.cpp \
 c.colorpanel.cpp \
+c.dsp.cpp \
 c.gain_tilde.cpp \
 c.incdec.cpp \
 c.knob.cpp \
@@ -22,6 +23,7 @@ c.preset.cpp \
 c.radio.cpp \
 c.rslider.cpp \
 c.scope_tilde.cpp \
+c.spectroscope_tilde.cpp \
 c.slider.cpp \
 c.tab.cpp \
 c.toggle.cpp

--- a/Chocolate/c.spectroscope_tilde.cpp
+++ b/Chocolate/c.spectroscope_tilde.cpp
@@ -233,6 +233,7 @@ void spectroscope_dsp(t_spectroscope *x, t_object *dsp, short *count, double sam
 
 void spectroscope_tick(t_spectroscope *x)
 {
+#ifdef __APPLE__
     if(x->f_real_mode)
     {
         mayer_realfft(x->f_buffer_size, x->f_buffer_real);
@@ -242,6 +243,7 @@ void spectroscope_tick(t_spectroscope *x)
     {
         
     }
+#endif
     
     ebox_invalidate_layer((t_ebox *)x, csym_spectrum_layer);
     ebox_redraw((t_ebox *)x);

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ pkglib_LTLIBRARIES = cream.la
 
 cream_la_CXXFLAGS = @PD_CPPFLAGS@ -s -O2 -fPIC -fpermissive 
 cream_la_LDFLAGS = -module -avoid-version -shared -shrext .@EXTENSION@  @PD_LDFLAGS@ -fPIC
-cream_la_LIBADD = Coffee/libCoffee.la Caramel/libCaramel.la Chocolate/libChocolate.la
+cream_la_LIBADD = Coffee/libCoffee.la Caramel/libCaramel.la Chocolate/libChocolate.la Cinnamon/libCinnamon.la
 cream_la_LIBADD += ThirdParty/PureData/Sources/libCicmWrapper.la
 
 cream_la_SOURCES = c.library.h \
@@ -27,7 +27,7 @@ ORIGDIR=pd-$(PACKAGE_NAME)_$(PACKAGE_VERSION)
 OS=$(shell uname -s)
 DISTBINDIR=$(DISTDIR)-$(OS)
 
-SUBDIRS=Coffee Caramel Chocolate
+SUBDIRS=Coffee Caramel Chocolate Cinnamon
 
 SUBDIRS+= ThirdParty/PureData
 SUBDIRS+= Package/Cream

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([cream], 0.3-git, musique@univ-paris8.fr,[cream],[https://github.com/CIC
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR(config)
-AC_CONFIG_FILES([Coffee/Makefile Chocolate/Makefile Caramel/Makefile])
+AC_CONFIG_FILES([Coffee/Makefile Chocolate/Makefile Caramel/Makefile Cinnamon/Makefile])
 AC_CONFIG_FILES([ThirdParty/PureData/Makefile ThirdParty/PureData/Sources/Makefile])
 AC_CONFIG_FILES([ThirdParty/PureData/Sources/ebox/Makefile ThirdParty/PureData/Sources/eclass/Makefile ThirdParty/PureData/Sources/ecommon/Makefile ThirdParty/PureData/Sources/egraphics/Makefile ThirdParty/PureData/Sources/eobj/Makefile ThirdParty/PureData/Sources/epopup/Makefile])
 AC_CONFIG_FILES([Package/Cream/Makefile Package/Cream/helps/Makefile Package/Cream/misc/Makefile])


### PR DESCRIPTION
When new objects are added to this library, Makefile.am should be updated to avoid linking errors.